### PR TITLE
Investigate Clock Frequency (w/ EDID) of ScreenPad Plus

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -822,7 +822,7 @@
 			<dict>
 				<key>AAPL,ig-platform-id</key>
 				<data>CQClPg==</data>
-				<key>AAPL01,override-no-connect</key>
+				<key>#AAPL01,override-no-connect</key>
 				<data>AP///////wAJ5X8IAAAAAAEdAQSlHwh4AtItk1FXjSgYTlIAAAABAQEBAQEBAQEBAQEBAQEBlBuAoHADMiAwIFUANVMQAAAaEhaAoHADMiAwIFUANVMQAAAaAAAA/gBCT0UgSEYKICAgICAgAAAA/gBOVjEyNkI1TS1ONDEKAO0=</data>
 				<key>device-id</key>
 				<data>pT4AAA==</data>

--- a/Resources/Firmware/BOE087F/46E74341751E
+++ b/Resources/Firmware/BOE087F/46E74341751E
@@ -1,0 +1,58 @@
+edid-decode (hex):
+
+00 ff ff ff ff ff ff 00 09 e5 7f 08 00 00 00 00
+01 1d 01 04 a5 1f 08 78 02 d2 2d 93 51 57 8d 28
+18 4e 52 00 00 00 01 01 01 01 01 01 01 01 01 01
+01 01 01 01 01 01 94 1b 80 a0 70 03 32 20 30 20
+55 00 35 53 10 00 00 1a 12 16 80 a0 70 03 32 20
+30 20 55 00 35 53 10 00 00 1a 00 00 00 fe 00 42
+4f 45 20 48 46 0a 20 20 20 20 20 20 00 00 00 fe
+00 4e 56 31 32 36 42 35 4d 2d 4e 34 31 0a 00 ed
+
+----------------
+
+Block 0, Base EDID:
+  EDID Structure Version & Revision: 1.4
+  Vendor & Product Identification:
+    Manufacturer: BOE
+    Model: 2175
+    Made in: week 1 of 2019
+  Basic Display Parameters & Features:
+    Digital display
+    Bits per primary color channel: 8
+    DisplayPort interface
+    Maximum image size: 31 cm x 8 cm
+    Gamma: 2.20
+    Supported color formats: RGB 4:4:4
+    First detailed timing includes the native pixel format and preferred refresh rate
+  Color Characteristics:
+    Red  : 0.5771, 0.3173
+    Green: 0.3398, 0.5527
+    Blue : 0.1562, 0.0957
+    White: 0.3076, 0.3212
+  Established Timings I & II: none
+  Standard Timings: none
+  Detailed Timing Descriptors:
+    DTD 1:  1920x515    60.074881 Hz 384:103   33.942 kHz     70.600000 MHz (309 mm x 83 mm)
+                 Hfront   48 Hsync  32 Hback   80 Hpol P
+                 Vfront    5 Vsync   5 Vback   40 Vpol N
+    DTD 2:  1920x515    48.076923 Hz 384:103   27.163 kHz     56.500000 MHz (309 mm x 83 mm)
+                 Hfront   48 Hsync  32 Hback   80 Hpol P
+                 Vfront    5 Vsync   5 Vback   40 Vpol N
+    Alphanumeric Data String: 'BOE HF'
+    Alphanumeric Data String: 'NV126B5M-N41'
+Checksum: 0xed
+
+----------------
+
+Warnings:
+
+Block 0, Base EDID:
+  Basic Display Parameters & Features: Dubious maximum image size (31x8 is smaller than 10x10 cm).
+
+Failures:
+
+Block 0, Base EDID:
+  Missing Display Product Name.
+
+EDID conformity: FAIL


### PR DESCRIPTION
Continue investigating ScreenPad Plus 'scrambled display-out' issue, potentially involving a custom WEG patch or edited EDID data injection.