### PR TITLE
Relicense project under more permissive license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2023, Cory Bennett
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -294,6 +294,9 @@ See this repository's [project board](https://github.com/users/Qonfused/projects
     </tr>
 </table>
 
+## License
+[BSD 3-Clause License](https://github.com/Qonfused/ASUS-ZenBook-Duo-14-UX481-Hackintosh/blob/main/LICENSE).
+
 ## Credits
 
 - [Apple](https://www.apple.com) for macOS

--- a/README.md
+++ b/README.md
@@ -300,4 +300,4 @@ See this repository's [project board](https://github.com/users/Qonfused/projects
 ## Credits
 
 - [Apple](https://www.apple.com) for macOS
-- @shiecldk for his work in the original [Zenbook Pro Duo 15" (UX582) OpenCore configuration and guide](https://github.com/shiecldk/ASUS-ZenBook-Pro-Duo-15-OLED-UX582-Hackintosh) that inspired this project.
+- [shiecldk](https://github.com/shiecldk) for his work in the original [Zenbook Pro Duo 15" (UX582) OpenCore configuration and guide](https://github.com/shiecldk/ASUS-ZenBook-Pro-Duo-15-OLED-UX582-Hackintosh) that inspired this project.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,8 @@ Hackintosh OpenCore configuration for ASUS ZenBook Duo 14 UX481(FA/FL)
   >
 </p>
 
-
-## License
-See the original repository license (protected under GNU GPL license).
-
-
 ## Current progress
 See this repository's [project board](https://github.com/users/Qonfused/projects/2/views/4) and [issues page](https://github.com/Qonfused/ASUS-ZenBook-Duo-14-UX481-Hackintosh/issues) for current progress.
-
-All changes are based off the [Zenbook Pro Duo 15" (UX582) OpenCore configuration and guide](https://github.com/shiecldk/ASUS-ZenBook-Pro-Duo-15-OLED-UX582-Hackintosh) from @shiecldk.
 
 ### macOS version support:
 > **Warning**
@@ -300,3 +293,8 @@ All changes are based off the [Zenbook Pro Duo 15" (UX582) OpenCore configuratio
       <td>Fully supported.</td>
     </tr>
 </table>
+
+## Credits
+
+- [Apple](https://www.apple.com) for macOS
+- @shiecldk for his work in the original [Zenbook Pro Duo 15" (UX582) OpenCore configuration and guide](https://github.com/shiecldk/ASUS-ZenBook-Pro-Duo-15-OLED-UX582-Hackintosh) that inspired this project.


### PR DESCRIPTION
The original repository's [GPLv3](https://github.com/shiecldk/ASUS-ZenBook-Pro-Duo-15-OLED-UX582-Hackintosh/blob/main/LICENSE) license enforces a viral copyleft clause (subject to the condition of using the same license downstream).

This is problematic for downstream contributions or larger works that are designed with interoperability in mind, as a strict interpretation of the license means that any code that “extends” a GPL-licensed project must also be GPL-licensed. Forcing the use of GPLv3 creates license incompatibilities, and is against the purpose of a project composed of various open-source plugins, modules, etc built on top of private macOS APIs.

As copyright is cumulative (i.e. as long as the original code is present, the original license still applies to that code), this repo as of #19 is no longer bound by the original repository's license. It is then desired to detach/extract this project and use a less restrictive license (BSD 3-Clause) as this enables clearer legal freedoms for any derivative works made from or linked to this project.

----

### Current tasks:
- [x] Add new BSD 3-Clause License
- [x] Update README
- [x] Extract repository network to include any dependent forks.