### PR TITLE
Refactor to use native keyboard backlight EC methods

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,10 @@
   "files.associations": {
     "*.lock": "yaml",
     ".serialdata": "yaml"
+  },
+  "[dsl]": {
+    "editor.detectIndentation": false,
+    "editor.insertSpaces": false,
+    "editor.tabSize": 4
   }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,13 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 The latest progress can be viewed on this repository's [project board](https://github.com/users/Qonfused/projects/2/views/11).
 
-## [0.5.1] - Unreleased
+## [0.5.1] - 2023-02-27
 
 This minor version includes small feature improvements and fixes, adding support for SMBIOS data patching and resolving regression issues from the previous release.
 
 ### Changed
 - Moved DiskArbitrationFixup build to separate repo ([`cd21c5e`](https://github.com/Qonfused/ASUS-ZenBook-Duo-14-UX481-Hackintosh/commit/cd21c5ef04cc1f0516e54930d74fb375c0f44c02))
 - Replaced VoodooI2CHID patch with VoodooInjector kext ([`97eb080`](https://github.com/Qonfused/ASUS-ZenBook-Duo-14-UX481-Hackintosh/commit/97eb0805231b6b1b320de10ce15deb0d4997bb66))
+- Refactored keyboard backlight to use native EC methods ([#38 PR](https://github.com/Qonfused/ASUS-ZenBook-Duo-14-UX481-Hackintosh/pull/38))
 
 ### Added
 - Added **.serialdata** patch script for custom SMBIOS data ([`e4ead15`](https://github.com/Qonfused/ASUS-ZenBook-Duo-14-UX481-Hackintosh/commit/e4ead158ef938c2a7c2cd02c62a28d1a2fc3f3dd))

--- a/src/ACPI/SSDT-ALSD.dsl
+++ b/src/ACPI/SSDT-ALSD.dsl
@@ -3,8 +3,9 @@
  */
 DefinitionBlock ("", "SSDT", 2, "UX481", "ALSD", 0x00000000)
 {
-    External (_SB_.ATKD, DeviceObj)
+	External (_SB_.ATKD, DeviceObj)
 	External (_SB_.ALSD, DeviceObj)
+	External (_SB_.ALSD._ALI, MethodObj)
 	External (ALSE, IntObj)
 
 	If (_OSI ("Darwin"))

--- a/src/ACPI/SSDT-ALSD.dsl
+++ b/src/ACPI/SSDT-ALSD.dsl
@@ -1,0 +1,28 @@
+/*
+ * Ambient Light Sensor device for AsusSMC
+ */
+DefinitionBlock ("", "SSDT", 2, "UX481", "ALSD", 0x00000000)
+{
+    External (_SB_.ATKD, DeviceObj)
+	External (_SB_.ALSD, DeviceObj)
+	External (ALSE, IntObj)
+
+	If (_OSI ("Darwin"))
+	{
+		// Enables ambient light sensor device.
+		// Reference: (ALSD)
+		ALSE = 0x02
+			
+		Scope (\_SB.ATKD)
+		{
+			Method (ALSS, 0, NotSerialized)
+			{
+				Return (^^ALSD._ALI ())
+			}
+
+			Method (ALSC, 1, NotSerialized)
+			{
+			}
+		}
+	}
+}

--- a/src/ACPI/SSDT-ATKD.dsl
+++ b/src/ACPI/SSDT-ATKD.dsl
@@ -7,41 +7,30 @@
 DefinitionBlock ("", "SSDT", 2, "UX481", "ATKD", 0x00000000)
 {
     External (_SB_.ATKD.IANE, MethodObj)
-    External (_SB_.KBLV, IntObj)
     External (_SB_.PCI0.LPCB.EC0_, DeviceObj)
     External (_SB_.PCI0.LPCB.EC0_.SPLC, MethodObj)
     External (_SB_.PCI0.LPCB.EC0_.SPSW, MethodObj)
     External (_SB_.PCI0.LPCB.EC0_.ST9E, MethodObj)
     External (_SB_.PCI0.LPCB.EC0_.WEBC, MethodObj)
-    External (_SB_.PCI0.LPCB.EC0_.XQ0D, MethodObj)
     External (_SB_.PCI0.LPCB.EC0_.XQ0E, MethodObj)
     External (_SB_.PCI0.LPCB.EC0_.XQ0F, MethodObj)
     External (_SB_.PCI0.LPCB.EC0_.XQ18, MethodObj)
     External (_SB_.PCI0.LPCB.EC0_.XQ31, MethodObj)
     External (_SB_.PCI0.LPCB.EC0_.XQ32, MethodObj)
     External (_SB_.PCI0.LPCB.EC0_.XQD5, MethodObj)
-    External (ATKP, IntObj)
     External (KFSK, IntObj)
 
-    Scope (_SB)
+    If (_OSI ("Darwin"))
     {
-        If (_OSI ("Darwin"))
+        // Sets FN+Lock disable default
+        // Reference: (WMNB, IIA0=0x00100023)
+        If ((KFSK == Zero))
         {
-            // Enables media key EC methods (including KBLD and KBLU methods)
-            // Reference: (ATKD.INIT)
-            ATKP = One
-
-            // Sets FN+Lock disable default
-            // Reference: (WMNB, IIA0=0x00100023)
-            If ((KFSK == Zero))
-            {
-                \_SB.PCI0.LPCB.EC0.ST9E (0x3C, 0xFF, 0x04)
-            }
+            \_SB.PCI0.LPCB.EC0.ST9E (0x3C, 0xFF, 0x04)
         }
     }
 
     Name (FNKL, Zero)
-    Name (DKLV, One)
     Name (BACT, Zero)
 
     Scope (_SB.PCI0.LPCB.EC0)
@@ -94,35 +83,6 @@ DefinitionBlock ("", "SSDT", 2, "UX481", "ATKD", 0x00000000)
             Else
             {
                 XQ0F ()
-            }
-        }
-
-        // FN + F7: Keyboard backlight slider
-        Method (_Q0D, 0, Serialized)
-        {
-            If (_OSI ("Darwin"))
-            {
-                // Switch direction at min/max backlight
-                Switch (ToInteger (KBLV))
-                {
-                    Case (Zero) { DKLV = Zero }
-                    Case (0x0F) { DKLV = One }
-                }
-
-                // Brightness down
-                If ((DKLV == One))
-                {
-                    \_SB.ATKD.IANE (0xC5)
-                }
-                // Brightness up
-                Else
-                {
-                    \_SB.ATKD.IANE (0xC4)
-                }
-            }
-            Else
-            {
-                XQ0D ()
             }
         }
 

--- a/src/ACPI/SSDT-ATKD.dsl
+++ b/src/ACPI/SSDT-ATKD.dsl
@@ -30,13 +30,11 @@ DefinitionBlock ("", "SSDT", 2, "UX481", "ATKD", 0x00000000)
         }
     }
 
-    Name (FNKL, Zero)
-    Name (BACT, Zero)
-
     Scope (_SB.PCI0.LPCB.EC0)
     {
         // FN + Lock: Toggle
         // Reference: (WMNB, IIA0=0x00100023)
+        Name (FNKL, Zero)
         Method (_QD5, 0, Serialized)
         {
             If (_OSI ("Darwin"))
@@ -65,7 +63,7 @@ DefinitionBlock ("", "SSDT", 2, "UX481", "ATKD", 0x00000000)
         {
             If (_OSI ("Darwin"))
             {
-                \_SB.ATKD.IANE (0x20)
+                ^^^^ATKD.IANE (0x20)
             }
             Else
             {
@@ -78,7 +76,7 @@ DefinitionBlock ("", "SSDT", 2, "UX481", "ATKD", 0x00000000)
         {
             If (_OSI ("Darwin"))
             {
-                \_SB.ATKD.IANE (0x10)
+                ^^^^ATKD.IANE (0x10)
             }
             Else
             {
@@ -88,6 +86,7 @@ DefinitionBlock ("", "SSDT", 2, "UX481", "ATKD", 0x00000000)
 
         // FN + F12: Battery charging threshold toggle
         // Reference: (SRSC; WNMB, IIA0=0x00120057)
+        Name (BACT, Zero)
         Method (_Q18, 0, NotSerialized)
         {
             If (_OSI ("Darwin"))

--- a/src/ACPI/SSDT-KBLC.dsl
+++ b/src/ACPI/SSDT-KBLC.dsl
@@ -4,20 +4,58 @@
 DefinitionBlock ("", "SSDT", 2, "UX481", "KBLC", 0x00000000)
 {
     External (_SB_.ATKD, DeviceObj)
+    External (_SB_.ATKD.XANE, MethodObj)
     External (_SB_.KBLV, IntObj)
     External (_SB_.PCI0.LPCB.EC0_.ST9E, MethodObj)
+    External (ATKP, IntObj)
 
-    Scope (\_SB.ATKD)
+    Scope (_SB)
     {
-        If (_OSI ("Darwin"))
+        // Enables media key EC methods (including KBLD and KBLU methods)
+        // Reference: (ATKD.INIT)
+        If (_OSI ("Darwin")) { ATKP = One }
+
+        Scope (ATKD)
         {
-            // Create keyboard backlight method for writing to EC register.
-            // Reference: (SLKB)
-            Method (SKBV, 1, NotSerialized)
+            // Stores backlight increment/decrement direction.
+            Name (DKLV, One)
+
+            // Modifies IANE method to override backlight notifier events.
+            // Reference: (KBLD, KBLU)
+            Method (IANE, 1, Serialized)
             {
-                \_SB.KBLV = (Arg0 / 0x10)
-                \_SB.PCI0.LPCB.EC0.ST9E (0x1F, 0xFF, Arg0)
-                Return (Arg0)
+                // Hijacks KBLU notifier calls in macOS
+                If (_OSI ("Darwin") && Arg0 == 0xC7) {
+                    Local0 = 0xC4           // 0xC4 - Backlight Up
+                    If (DKLV) { Local0++ }  // 0xC5 - Backlight Down
+                }
+                Else { Local0 = Arg0 }      // For all other events
+
+                XANE (Local0)
+            }
+
+            If (_OSI ("Darwin"))
+            {
+                // Create keyboard backlight method for writing to EC register.
+                // Reference: (SLKB)
+                Method (SKBV, 1, NotSerialized)
+                {
+                    Local0 = (Arg0 / 0x10)
+                    // Switch direction at min/max backlight
+                    Switch (Local0)
+                    {
+                        Case (Zero) { DKLV = Zero }
+                        Case (0x0F) { DKLV = One }
+                    }
+                    // Handle unset initial backlight
+                    If (!^^KBLV && DKLV) { DKLV-- }
+
+                    // Set new backlight value
+                    ^^KBLV = Local0
+                    ^^PCI0.LPCB.EC0.ST9E (0x1F, 0xFF, Arg0)
+
+                    Return (Arg0)
+                }
             }
         }
     }

--- a/src/ACPI/SSDT-PNLF.dsl
+++ b/src/ACPI/SSDT-PNLF.dsl
@@ -5,13 +5,9 @@
 DefinitionBlock ("", "SSDT", 2, "DRTNIA", "PNLF", 0x00000000)
 {
     External (_SB_.PCI0.GFX0, DeviceObj)
-    External (ALSE, IntObj)
 
     If (_OSI ("Darwin"))
     {
-        // Enables ambient light sensor device.
-        ALSE = 0x02
-
         Device (\_SB.PCI0.GFX0.PNLF)
         {
             Name (_HID, EisaId ("APP0002"))

--- a/src/build.yml
+++ b/src/build.yml
@@ -6,6 +6,7 @@ include:
   "*":
   - ".contentVisibility"
   acpi:
+    SSDT-ALSD: "ACPI/SSDT-ALSD.dsl"
     SSDT-ATKD: "ACPI/SSDT-ATKD.dsl"
     SSDT-AWAK: "ACPI/SSDT-AWAC.dsl"
     SSDT-EC-USBX: "ACPI/SSDT-EC-USBX.dsl"

--- a/src/config.yml
+++ b/src/config.yml
@@ -24,12 +24,12 @@ ACPI:
     - Comment:                        String  | "[ATKD] Screenpad Disable - Rename _Q32 to XQ32"
       Find:                           Data    | <5F513332>
       Replace:                        Data    | <58513332>
-    - Base:                           String  | "\_SB.PCI0.I2C1.ETPD"
+    - Base:                           String  | "_SB.PCI0.I2C1.ETPD"
       Comment:                        String  | "[GPI0] ETPD - Rename _CRS to XCRS"
       Count:                          Number  | 1
       Find:                           Data    | <5F435253>
       Replace:                        Data    | <58435253>
-    - Base:                           String  | "\_SB.PCI0.I2C0.TPL1"
+    - Base:                           String  | "_SB.PCI0.I2C0.TPL1"
       Comment:                        String  | "[GPI0] TPL1 - Rename _CRS to XCRS"
       Count:                          Number  | 1
       Find:                           Data    | <5F435253>

--- a/src/config.yml
+++ b/src/config.yml
@@ -1,6 +1,11 @@
 ACPI:
   Delete:                             Macro   | @Clear
   Patch:
+    - Base:                           String  | "_SB.ATKD"
+      Comment:                        String  | "[KBLC] Keyboard Backlight - Rename IANE to XANE"
+      Count:                          Number  | 1
+      Find:                           Data    | <49414E45>
+      Replace:                        Data    | <58414E45>
     - Comment:                        String  | "[ATKD] FN Lock - Rename _QD5 to XQD5"
       Find:                           Data    | <5F514435>
       Replace:                        Data    | <58514435>
@@ -10,9 +15,6 @@ ACPI:
     - Comment:                        String  | "[ATKD] FN+F5 - Rename _Q0F to XQ0F"
       Find:                           Data    | <5F513046>
       Replace:                        Data    | <58513046>
-    - Comment:                        String  | "[ATKD] FN+F7 - Rename _Q0D to XQ0D"
-      Find:                           Data    | <5F513044>
-      Replace:                        Data    | <58513044>
     - Comment:                        String  | "[ATKD] FN+F12 - Rename _Q18 to XQ18"
       Find:                           Data    | <5F513138>
       Replace:                        Data    | <58513138>


### PR DESCRIPTION
Reimplementation of native backlight methods for a more standardized spec-compliant implementation less error-prone from model-specific quirks.

Resolves #21.

## Tasks
- [x] Refactor keyboard backlight methods
- [x] Refactor ambient light sensor methods